### PR TITLE
Add MC smearing capability

### DIFF
--- a/app/src/main/groovy/org/jlab/analysis/Analysis.groovy
+++ b/app/src/main/groovy/org/jlab/analysis/Analysis.groovy
@@ -1422,12 +1422,6 @@ public class Analysis {
             MCDecays mcdecays = new MCDecays(this._mcdecay,this._parents,this._dpMap,reader,event,this._constants);
             mcdecays.setMatchingMap(fullParticleList); //NOTE: THIS METHOD WILL AND NEEDS TO SET FULL PARTICLE LIST!
 
-            // Apply the MC smearing algorithm to the reconstructed particles
-            if (this._use_mcsmearing) {
-                ArrayList<DecayProduct> smeared_rec_plist = this._mcsmearing.smear(decays.getFullParticleList(),mcdecays.getFullParticleList());
-                decays.setFullParticleList(smeared_rec_plist);
-            }
-
             // Check for event pid tag if requested
             if (this._require_tag) {
                 boolean found_tag = false;
@@ -1436,10 +1430,18 @@ public class Analysis {
                 if (!this.filter(decays.getFullParticleList())) { continue; }
             }
 
-            // Get combined list of particle combinations from REC::Particle and MC::Lund banks
+            // Initialize lists of particle combinations from REC::Particle and MC::Lund banks
             ArrayList<ArrayList<DecayProduct>> list;
             LinkedHashMap<Integer,Integer> recMatchingMap = mcdecays.getMatchingMap();
             ArrayList<DecayProduct> mcFullParticleList = mcdecays.getFullParticleList();
+
+            // Apply the MC smearing algorithm to the reconstructed particles
+            if (this._use_mcsmearing) {
+                ArrayList<DecayProduct> smeared_rec_plist = this._mcsmearing.smear(decays.getFullParticleList(),mcFullParticleList,recMatchingMap);
+                decays.setFullParticleList(smeared_rec_plist);
+            }
+
+            // Get combined list of particle combinations from REC::Particle and MC::Lund banks
             if (!this._require_pid) { list = decays.mergeComboChargeList(recMatchingMap,mcFullParticleList); }
             if (this._require_pid)  { list = decays.mergeComboPidList(recMatchingMap,mcFullParticleList); } // if (this._parents.size()!=0) { list = decays.mergeComboPidList(mcdecays.getCheckedComboPidList()); }
 

--- a/app/src/main/groovy/org/jlab/analysis/Analysis.groovy
+++ b/app/src/main/groovy/org/jlab/analysis/Analysis.groovy
@@ -44,6 +44,7 @@ public class Analysis {
     protected String                         _qaMethod;
     protected FiducialCuts                   _fiducialCuts;
     protected MomentumCorrections            _momCorrections;
+    protected MCSmearing                     _mcsmearing;
     protected String                         _inPath;
     protected String                         _outPath;
     protected ROOTFile                       _outFile;
@@ -79,6 +80,7 @@ public class Analysis {
     protected static int     _notify       = 0;                     // notify how many events have been added out of total read so far after given number of events, does nothing if zero
     protected static boolean _addVertices  = false;                 // Add vertices to tree
     protected static boolean _addAngles    = false;                 // Add angles (in degrees) to tree
+    protected static boolean _use_mcsmearing = false;               // Option to smear reconstructed momentum, theta, phi, values using MC truth values and fitted resolutions and means.
 
     // Tagging options
     protected static ArrayList<Integer>       _tag_pids   = new ArrayList<Integer>();        // List of pid tags for event, just checks that at least one is present in event
@@ -100,6 +102,7 @@ public class Analysis {
         this._qaMethod         = new String("OkForAsymmetry");
         this._fiducialCuts     = new FiducialCuts(this._constants);
         this._momCorrections   = new MomentumCorrections();
+        this._mcsmearing       = new MCSmearing();
         this._inPath           = new String("");
         this._outPath          = new String("Analysis.root");
         this._tupleNames       = new String("");
@@ -127,6 +130,7 @@ public class Analysis {
         this._qaMethod         = new String("OkForAsymmetry");
         this._fiducialCuts     = new FiducialCuts(this._constants);
         this._momCorrections   = new MomentumCorrections();
+        this._mcsmearing       = new MCSmearing();
         this._inPath           = inPath;
         this._outPath          = outPath;
         this._tupleNames       = new String("");
@@ -158,6 +162,7 @@ public class Analysis {
         this._qaMethod         = new String("OkForAsymmetry");
         this._fiducialCuts     = new FiducialCuts(this._constants);
         this._momCorrections   = new MomentumCorrections();
+        this._mcsmearing       = new MCSmearing();
         this._inPath           = inPath;
         this._outPath          = outPath;
         this._tupleNames       = new String("");
@@ -925,6 +930,44 @@ public class Analysis {
     }
 
     /**
+    * Set the option to use MC smearing.
+    * @param use_mcsmearing
+    */
+    protected void setMCSmearing(boolean use_mcsmearing) {
+
+        this._use_mcsmearing = use_mcsmearing;
+    }
+
+    /**
+    * Set data smearing fractions.
+    * @param smearing_mom
+    * @param smearing_theta
+    * @param smearing_phi
+    */
+    protected void setMCSmearing(double smearing_mom, double smearing_theta, double smearing_phi) {
+
+        this._mcsmearing.setSmearing(smearing_mom, smearing_theta, smearing_phi);
+    }
+
+    /**
+    * Set the option to offset MC smeared values as well.
+    * @param use_mu
+    */
+    protected void setMCSmearingUseMu(boolean use_mu) {
+
+        this._mcsmearing.setUseMu(use_mu);
+    }
+
+    /**
+    * Load JSON path for MC smearing.
+    * @param mcsmearing_jsonpath
+    */
+    protected void loadMCSmearingJSON(String jsonpath) {
+
+        this._mcsmearing.loadJSON(jsonpath);
+    }
+
+    /**
     * Set boolean for requiring matching decay in mc.
     * @param MC
     */
@@ -1378,6 +1421,12 @@ public class Analysis {
             // Create MCDecays object with MC Matching map which will force it to only use combos of particles coming from this map and return a default 0.0 particle combo if no matches are found
             MCDecays mcdecays = new MCDecays(this._mcdecay,this._parents,this._dpMap,reader,event,this._constants);
             mcdecays.setMatchingMap(fullParticleList); //NOTE: THIS METHOD WILL AND NEEDS TO SET FULL PARTICLE LIST!
+
+            // Apply the MC smearing algorithm to the reconstructed particles
+            if (this._use_mcsmearing) {
+                ArrayList<DecayProduct> smeared_rec_plist = this._mcsmearing.smear(decays.getFullParticleList(),mcdecays.getFullParticleList());
+                decays.setFullParticleList(smeared_rec_plist);
+            }
 
             // Check for event pid tag if requested
             if (this._require_tag) {

--- a/app/src/main/groovy/org/jlab/analysis/DecayProduct.groovy
+++ b/app/src/main/groovy/org/jlab/analysis/DecayProduct.groovy
@@ -540,7 +540,7 @@ public class DecayProduct {
         double py = p * Math.sin(theta) * Math.sin(phi);
         double pz = p * Math.cos(theta);
 
-        this.setPxPyPzM(px,py,pz,m);
+        this.setPxPyPzM(px,py,pz,mass);
     }
 
     /**

--- a/app/src/main/groovy/org/jlab/analysis/DecayProduct.groovy
+++ b/app/src/main/groovy/org/jlab/analysis/DecayProduct.groovy
@@ -528,6 +528,22 @@ public class DecayProduct {
     }
 
     /**
+    * Set particle's lorentz vector using particle mass instead of energy.
+    * @param px
+    * @param py
+    * @param pz
+    * @param mass
+    */
+    protected void setPThetaPhiM(double p, double theta, double phi, double mass) {
+
+        double px = p * Math.sin(theta) * Math.cos(phi);
+        double py = p * Math.sin(theta) * Math.sin(phi);
+        double pz = p * Math.cos(theta);
+
+        this.setPxPyPzM(px,py,pz,m);
+    }
+
+    /**
     * Set particle's x vertex.
     * @param vx
     */

--- a/app/src/main/groovy/org/jlab/analysis/Decays.groovy
+++ b/app/src/main/groovy/org/jlab/analysis/Decays.groovy
@@ -87,6 +87,15 @@ public class Decays {
 
     /**
     * Set full list of particles in event. (Used for pid tagging events.)
+    * @param fplist
+    */
+    protected void setFullParticleList(ArrayList<DecayProduct> fplist) {
+
+        this._particleList = fplist;
+    }
+
+    /**
+    * Set full list of particles in event. (Used for pid tagging events.)
     */
     protected void setFullParticleList() {
 

--- a/app/src/main/groovy/org/jlab/analysis/Decays.groovy
+++ b/app/src/main/groovy/org/jlab/analysis/Decays.groovy
@@ -42,6 +42,7 @@ public class Decays {
     protected ArrayList<ArrayList<DecayProduct>> _comboPidList;
     protected ArrayList<DecayProduct>            _chargeList;     // List of lists for each charge in decay
     protected ArrayList<ArrayList<DecayProduct>> _comboChargeList;
+    protected boolean                            _setFullParticleList; // Flag indicating whether full  particle list has been set.
 
     /** 
     * Default constructor
@@ -88,6 +89,12 @@ public class Decays {
     * Set full list of particles in event. (Used for pid tagging events.)
     */
     protected void setFullParticleList() {
+
+        // Set flag
+        this._setFullParticleList = true;
+
+        // Reset particle list
+        this._particleList = new ArrayList<DecayProduct>();
 
         this._event.read(this._bank);
         for (int i = 0; i < this._bank.getRows(); i++) {
@@ -150,7 +157,7 @@ public class Decays {
     */
     protected ArrayList<DecayProduct> getFullParticleList() {
 
-        this.setFullParticleList();
+        if (!this._setFullParticleList) this.setFullParticleList();
 
         return this._particleList;
     }

--- a/app/src/main/groovy/org/jlab/analysis/Decays.groovy
+++ b/app/src/main/groovy/org/jlab/analysis/Decays.groovy
@@ -42,7 +42,7 @@ public class Decays {
     protected ArrayList<ArrayList<DecayProduct>> _comboPidList;
     protected ArrayList<DecayProduct>            _chargeList;     // List of lists for each charge in decay
     protected ArrayList<ArrayList<DecayProduct>> _comboChargeList;
-    protected boolean                            _setFullParticleList; // Flag indicating whether full  particle list has been set.
+    protected boolean                            _setFullParticleList = false; // Flag indicating whether full  particle list has been set.
 
     /** 
     * Default constructor

--- a/app/src/main/groovy/org/jlab/analysis/MCDecays.groovy
+++ b/app/src/main/groovy/org/jlab/analysis/MCDecays.groovy
@@ -44,7 +44,7 @@ public class MCDecays {
     protected ArrayList<DecayProduct>            _parChargeList;     // List of lists for each charge in parent decay
     protected ArrayList<ArrayList<DecayProduct>> _parComboChargeList;
     protected LinkedHashMap<Integer,Integer>     _recMatchingMap;
-    protected boolean                            _setFullParticleList; // Flag indicating whether full  particle list has been set.
+    protected boolean                            _setFullParticleList = false; // Flag indicating whether full  particle list has been set.
 
     /** 
     * Constructor stub

--- a/app/src/main/groovy/org/jlab/analysis/MCDecays.groovy
+++ b/app/src/main/groovy/org/jlab/analysis/MCDecays.groovy
@@ -85,6 +85,15 @@ public class MCDecays {
         Collections.sort(this._parCharges); //IMPORTANT: Must be sorted otherwise algorithm won't work.
     }
 
+    /**
+    * Set full list of particles in event. (Used for pid tagging events.)
+    * @param fplist
+    */
+    protected void setFullParticleList(ArrayList<DecayProduct> fplist) {
+
+        this._particleList = fplist;
+    }
+
    /**
     * Set full list of particles in event. (Used for pid tagging events.)
     */

--- a/app/src/main/groovy/org/jlab/analysis/MCDecays.groovy
+++ b/app/src/main/groovy/org/jlab/analysis/MCDecays.groovy
@@ -44,6 +44,7 @@ public class MCDecays {
     protected ArrayList<DecayProduct>            _parChargeList;     // List of lists for each charge in parent decay
     protected ArrayList<ArrayList<DecayProduct>> _parComboChargeList;
     protected LinkedHashMap<Integer,Integer>     _recMatchingMap;
+    protected boolean                            _setFullParticleList; // Flag indicating whether full  particle list has been set.
 
     /** 
     * Constructor stub
@@ -89,6 +90,12 @@ public class MCDecays {
     */
     protected void setFullParticleList() {
 
+        // Set flag
+        this._setFullParticleList = true;
+
+        // Reset particle list
+        this._particleList = new ArrayList<DecayProduct>();
+
         this._event.read(this._bank);
         for (int i = 0; i < this._bank.getRows(); i++) {
 
@@ -125,7 +132,7 @@ public class MCDecays {
     */
     protected ArrayList<DecayProduct> getFullParticleList() {
 
-        this.setFullParticleList();
+        if (!this._setFullParticleList) this.setFullParticleList();
 
         return this._particleList;
     }

--- a/app/src/main/groovy/org/jlab/analysis/MCSmearing.groovy
+++ b/app/src/main/groovy/org/jlab/analysis/MCSmearing.groovy
@@ -1,0 +1,164 @@
+
+package org.jlab.analysis;
+
+// Groovy Imports
+import groovy.json.JsonSlurper;
+import java.util.Random;
+import groovy.transform.CompileStatic;
+
+/**
+* Allows one to smear reconstructed momentum, polar angle, and azimuthal angle values around the MC truth values
+* with differences taken randomly from a Gaussian distribution.  The resolutions (widths) of the Gaussians should be taken
+* from fits to the widths in momentum bins and supplied as json files giving the resolutions and bin limits.
+*
+* @version 1.0
+* @author  Matthew McEneaney
+*/
+
+@CompileStatic
+public class MCSmearing {
+
+    public String  _jsonpath;
+
+    double _smearing_p     = 0.50;
+    double _smearing_theta = 0.50;
+    double _smearing_phi   = 0.50;
+
+    Map<Integer, Map<Integer,Cut>> _binlims_map;
+    Map<Integer, Map<Integer,Double>> _mc_resolution_p_map;
+    Map<Integer, Map<Integer,Double>> _mc_resolution_theta_map;
+    Map<Integer, Map<Integer,Double>> _mc_resolution_phi_map;
+
+    Random _rng;
+
+    public MCSmearing(String jsonpath, double smearing_p, double smearing_theta, double smearing_phi) {
+
+        // Reset paths and smearing values
+        this._jsonpath = jsonpath;
+        this._smearing_p = smearing_p;
+        this._smearing_theta = smearing_theta;
+        this._smearing_phi = smearing_phi;
+
+        // Load the JSON data
+        File jsonFile = new File(this._jsonpath);
+        JsonSlurper jsonSlurper = new JsonSlurper();
+        Map<String, Object> jsonmap = (Map<String, Object>)jsonSlurper.parse(jsonFile);
+        Map<String,Map<Integer,List<Double>>> binlims_map = (Map<String,Map<Integer,List<Double>>>)jsonmap.get("binlims");
+
+        // Initialize maps
+        this._binlims_map = new Map<Integer, Map<Integer,Cut>>();
+        this._mc_resolution_p_map = new Map<Integer, Map<Integer,Double>>();
+        this._mc_resolution_theta_map = new Map<Integer, Map<Integer,Double>>();
+        this._mc_resolution_phi_map = new Map<Integer, Map<Integer,Double>>();
+
+        // Add bin limits to map
+        for (Integer pid : mymap.values()) {
+            Map<Integer,Cut> new_binlim_map = new Map<Integer,Cut>();
+            for (Integer binid : mymap.get(pid).values()) {
+                double xmin = binlim_map.get(binid).at(0);
+                double xmin = binlim_map.get(binid).at(1);
+                Cut cut = (double x) -> {if(x >= xmin && x<xmax ) {return true;} else {return false;}};
+                new_binlim_map.put(binid,cut);
+            }
+            this._binlims_map.put(pid,new_binlim_map);
+        }
+
+        // Load MC resolution maps
+        if (jsonmap.containsKey("p")) {
+            System.out.println("Loading momentum ('p') MC resolution map...");
+            this._mc_resolution_p_map = (Map<Integer,Map<Integer,Double>>)jsonmap.get("p");
+        }
+        if (jsonmap.containsKey("theta")) {
+            System.out.println("Loading polar angle ('theta') MC resolution map...");
+            this._mc_resolution_theta_map = (Map<Integer,Map<Integer,Double>>)jsonmap.get("theta");
+        }
+        if (jsonmap.containsKey("phi")) {
+            System.out.println("Loading azimuthal angle ('phi') MC resolution map...");
+            this._mc_resolution_phi_map = (Map<Integer,Map<Integer,Double>>)jsonmap.get("phi");
+        }
+
+        // Create random number generator
+        this._rng = new Random();
+    }
+
+    /**
+    * Apply MC smearing to a given particle and MC truth particle
+    * @param p
+    * @param p_mc
+    * @return new_p
+    */
+    protected DecayProduct applySmearing(DecayProduct p, MCDecayProduct p_mc) {
+
+        // Generate a random Gaussian float
+        double gaussian = this._rng.nextGaussian() // mean = 0.0, std dev = 1.0
+
+        // Set PID, momentum, theta, phi for REC particle
+        int pid_dt      = p.pid();
+        double p_dt     = p.p();
+        double theta_dt = p.theta();
+        double phi_dt   = p.phi();
+
+        // Set PID and momentum theta phi for REC particle
+        int pid_mc      = p_mc.pid();
+        double p_mc     = p_mc.p();
+        double theta_mc = p_mc.theta();
+        double phi_mc   = p_mc.phi();
+
+        // Smear the momentum
+        double sigma_p_mc = 0.0;
+
+        // Check the momentum bin
+        int binid_mc = -1;
+        if (this._binlims_p_map.containsKey(pid_dt)) {
+
+            // Get cut map for pid
+            Map<Integer, Cut> cut_map = this._binlims_map.get(pid_dt);
+
+            // Loop cut map
+            for (Integer binid : cut_map.values()) {
+
+                // Check which bin the MC truth is in
+                if (cut_map.get(binid)(p_mc)) {
+                    binid_mc = binid;
+                }
+            }
+        }
+
+        // Get the MC momentum resolution
+        double sigma_p_mc = 0.0;
+        if (binid_mc>=0 && this._mc_resolution_p_map.get(pid_dt).containsKey(binid_mc)) {
+            sigma_p_mc = this._mc_resolution_p_map.get(pid_dt).get(binid_mc);
+        }
+
+        // Smear the momentum
+        double sigma_p = sigma_p_mc * Math.sqrt(1.0+this._smearing_p*this._smearing_p); // Add in the additional smearing for data
+        double new_p_dt = p_mc + gaussian * sigma_p;
+
+        // Get the MC theta resolution
+        double sigma_theta_mc = 0.0;
+        if (binid_mc>=0 && this._mc_resolution_theta_map.get(pid_dt).containsKey(binid_mc)) {
+            sigma_theta_mc = this._mc_resolution_theta_map.get(pid_dt).get(binid_mc);
+        }
+
+        // Smear the theta
+        double sigma_theta = sigma_theta_mc * Math.sqrt(1.0+this._smearing_theta*this._smearing_theta); // Add in the additional smearing for data
+        double new_theta_dt = theta_mc + gaussian * sigma_theta;
+
+        // Get the MC phi resolution
+        double sigma_phi_mc = 0.0;
+        if (binid_mc>=0 && this._mc_resolution_phi_map.get(pid_dt).containsKey(binid_mc)) {
+            sigma_phi_mc = this._mc_resolution_phi_map.get(pid_dt).get(binid_mc);
+        }
+
+        // Smear the phi
+        double sigma_phi = sigma_phi_mc * Math.sqrt(1.0+this._smearing_phi*this._smearing_phi); // Add in the additional smearing for data
+        double new_phi_dt = phi_mc + gaussian * sigma_phi;
+
+        // Reset momentum vector
+        DecayProduct new_p = p.clone();
+        new_p.setPThetaPhiM(new_p_dt, new_theta_dt, new_phi_dt, p.m());
+        return new_p;
+        
+    }
+
+} // public class MCSmearing {

--- a/app/src/main/groovy/org/jlab/analysis/MCSmearing.groovy
+++ b/app/src/main/groovy/org/jlab/analysis/MCSmearing.groovy
@@ -117,6 +117,8 @@ public class MCSmearing {
     */
     protected void loadJSON(String jsonpath) {
 
+        this._jsonpath = jsonpath;
+
         // Load the JSON data
         File jsonFile = new File(this._jsonpath);
         JsonSlurper jsonSlurper = new JsonSlurper();

--- a/app/src/main/groovy/org/jlab/analysis/MCSmearing.groovy
+++ b/app/src/main/groovy/org/jlab/analysis/MCSmearing.groovy
@@ -136,6 +136,7 @@ public class MCSmearing {
     protected void loadJSON(String jsonpath) {
 
         this._jsonpath = jsonpath;
+        System.out.println("INFO: Loading MC smearing maps from: "+this._jsonpath);
 
         // Load the JSON data
         File jsonFile = new File(this._jsonpath);
@@ -152,7 +153,7 @@ public class MCSmearing {
         // Load bin limits map
         LinkedHashMap<String,LinkedHashMap<String,ArrayList<Double>>> mombinlims_map = new LinkedHashMap<String,LinkedHashMap<String,ArrayList<Double>>>();
         if (jsonmap.containsKey(this._mombinlims_key)) {
-            System.out.println("Loading momentum bin limits ('"+this._mombinlims_key+"') map...");
+            System.out.println("INFO: Loading momentum bin limits ('"+this._mombinlims_key+"') map...");
             mombinlims_map = jsonmap.get(this._mombinlims_key);
         }
 
@@ -173,7 +174,7 @@ public class MCSmearing {
 
         // Load MC resolution maps
         if (jsonmap.containsKey(this._resolution_mom_map_key)) {
-            System.out.println("Loading momentum ('"+this._resolution_mom_map_key+"') MC resolution map...");
+            System.out.println("INFO: Loading momentum ('"+this._resolution_mom_map_key+"') MC resolution map...");
             LinkedHashMap<String,LinkedHashMap<String,ArrayList<Double>>> mc_resolution_mom_map = jsonmap.get(this._resolution_mom_map_key);
 
             // Add entries to map using correct types since JSON only stores keys as strings
@@ -189,7 +190,7 @@ public class MCSmearing {
             }
         }
         if (jsonmap.containsKey(this._resolution_theta_map_key)) {
-            System.out.println("Loading polar angle ('"+this._resolution_theta_map_key+"') MC resolution map...");
+            System.out.println("INFO: Loading polar angle ('"+this._resolution_theta_map_key+"') MC resolution map...");
             LinkedHashMap<String,LinkedHashMap<String,ArrayList<Double>>> mc_resolution_theta_map = jsonmap.get(this._resolution_theta_map_key);
 
             // Add entries to map using correct types since JSON only stores keys as strings
@@ -205,7 +206,7 @@ public class MCSmearing {
             }
         }
         if (jsonmap.containsKey(this._resolution_phi_map_key)) {
-            System.out.println("Loading azimuthal angle ('"+this._resolution_phi_map_key+"') MC resolution map...");
+            System.out.println("INFO: Loading azimuthal angle ('"+this._resolution_phi_map_key+"') MC resolution map...");
             LinkedHashMap<String,LinkedHashMap<String,ArrayList<Double>>> mc_resolution_phi_map = jsonmap.get(this._resolution_phi_map_key);
 
             // Add entries to map using correct types since JSON only stores keys as strings
@@ -220,6 +221,7 @@ public class MCSmearing {
                 this._mc_resolution_phi_map.put(pid,smearing_map);
             }
         }
+        System.out.println("INFO: Finished loading MC smearing maps.");
 
         // Create random number generator
         this._rng = new Random();

--- a/app/src/main/groovy/org/jlab/analysis/MCSmearing.groovy
+++ b/app/src/main/groovy/org/jlab/analysis/MCSmearing.groovy
@@ -140,7 +140,8 @@ public class MCSmearing {
         // Load the JSON data
         File jsonFile = new File(this._jsonpath);
         JsonSlurper jsonSlurper = new JsonSlurper();
-        LinkedHashMap<String, Object> jsonmap = (LinkedHashMap<String, Object>)jsonSlurper.parse(jsonFile);
+        Map _jsonmap = (Map)jsonSlurper.parse(jsonFile); //NOTE: groovy.json.JsonSlurper uses the internal class LazyMap so you have to read this as `Map` and then convert to LinkedHashMap since the class hierarchies are not connected.
+        LinkedHashMap<String, LinkedHashMap<String,LinkedHashMap<String,ArrayList<Double>>>> jsonmap = new LinkedHashMap<String, LinkedHashMap<String,LinkedHashMap<String,ArrayList<Double>>>>(_jsonmap);
 
         // Initialize maps
         this._bincuts_map = new LinkedHashMap<Integer, LinkedHashMap<Integer,Cut>>();
@@ -152,17 +153,18 @@ public class MCSmearing {
         LinkedHashMap<String,LinkedHashMap<String,ArrayList<Double>>> mombinlims_map = new LinkedHashMap<String,LinkedHashMap<String,ArrayList<Double>>>();
         if (jsonmap.containsKey(this._mombinlims_key)) {
             System.out.println("Loading momentum bin limits ('"+this._mombinlims_key+"') map...");
-            mombinlims_map = (LinkedHashMap<String,LinkedHashMap<String,ArrayList<Double>>>)jsonmap.get(this._mombinlims_key);
+            mombinlims_map = jsonmap.get(this._mombinlims_key);
         }
 
         // Add cuts to bin cuts map
         for (String str_pid : mombinlims_map.keySet()) {
             Integer pid = Integer.parseInt(str_pid);
             LinkedHashMap<Integer,Cut> new_binlim_map = new LinkedHashMap<Integer,Cut>();
-            for (String str_binid : mombinlims_map.get(str_pid).keySet()) {
+            LinkedHashMap<String,ArrayList<Double>> mombinlims_map_pid = new LinkedHashMap<String,ArrayList<Double>>(mombinlims_map.get(str_pid));
+            for (String str_binid : mombinlims_map_pid.keySet()) {
                 Integer binid = Integer.parseInt(str_binid);
-                double xmin = mombinlims_map.get(str_pid).get(str_binid).get(0);
-                double xmax = mombinlims_map.get(str_pid).get(str_binid).get(1);
+                double xmin = mombinlims_map_pid.get(str_binid).get(0);
+                double xmax = mombinlims_map_pid.get(str_binid).get(1);
                 Cut cut = (double x) -> {if(x >= xmin && x<xmax ) {return true;} else {return false;}};
                 new_binlim_map.put(binid,cut);
             }
@@ -178,9 +180,10 @@ public class MCSmearing {
             for (String str_pid : mc_resolution_mom_map.keySet()) {
                 Integer pid = Integer.parseInt(str_pid);
                 LinkedHashMap<Integer,ArrayList<Double>> smearing_map = new LinkedHashMap<Integer,ArrayList<Double>>();
-                for (String str_binid : mc_resolution_mom_map.get(str_pid).keySet()) {
+                LinkedHashMap<String,ArrayList<Double>> mc_resolution_mom_map_pid = new LinkedHashMap<String,ArrayList<Double>>(mc_resolution_mom_map.get(str_pid));
+                for (String str_binid : mc_resolution_mom_map_pid.keySet()) {
                     Integer binid = Integer.parseInt(str_binid);
-                    smearing_map.put(binid,mc_resolution_mom_map.get(str_pid).get(str_binid));
+                    smearing_map.put(binid,mc_resolution_mom_map_pid.get(str_binid));
                 }
                 this._mc_resolution_mom_map.put(pid,smearing_map);
             }
@@ -193,9 +196,10 @@ public class MCSmearing {
             for (String str_pid : mc_resolution_theta_map.keySet()) {
                 Integer pid = Integer.parseInt(str_pid);
                 LinkedHashMap<Integer,ArrayList<Double>> smearing_map = new LinkedHashMap<Integer,ArrayList<Double>>();
-                for (String str_binid : mc_resolution_theta_map.get(str_pid).keySet()) {
+                LinkedHashMap<String,ArrayList<Double>> mc_resolution_theta_map_pid = new LinkedHashMap<String,ArrayList<Double>>(mc_resolution_theta_map.get(str_pid));
+                for (String str_binid : mc_resolution_theta_map_pid.keySet()) {
                     Integer binid = Integer.parseInt(str_binid);
-                    smearing_map.put(binid,mc_resolution_theta_map.get(str_pid).get(str_binid));
+                    smearing_map.put(binid,mc_resolution_theta_map_pid.get(str_binid));
                 }
                 this._mc_resolution_theta_map.put(pid,smearing_map);
             }
@@ -208,9 +212,10 @@ public class MCSmearing {
             for (String str_pid : mc_resolution_phi_map.keySet()) {
                 Integer pid = Integer.parseInt(str_pid);
                 LinkedHashMap<Integer,ArrayList<Double>> smearing_map = new LinkedHashMap<Integer,ArrayList<Double>>();
-                for (String str_binid : mc_resolution_phi_map.get(str_pid).keySet()) {
+                LinkedHashMap<String,ArrayList<Double>> mc_resolution_phi_map_pid = new LinkedHashMap<String,ArrayList<Double>>(mc_resolution_phi_map.get(str_pid));
+                for (String str_binid : mc_resolution_phi_map_pid.keySet()) {
                     Integer binid = Integer.parseInt(str_binid);
-                    smearing_map.put(binid,mc_resolution_phi_map.get(str_pid).get(str_binid));
+                    smearing_map.put(binid,mc_resolution_phi_map_pid.get(str_binid));
                 }
                 this._mc_resolution_phi_map.put(pid,smearing_map);
             }

--- a/app/src/main/groovy/org/jlab/analysis/MCSmearing.groovy
+++ b/app/src/main/groovy/org/jlab/analysis/MCSmearing.groovy
@@ -305,15 +305,20 @@ public class MCSmearing {
         
     }
 
-    protected ArrayList<DecayProduct> smear(ArrayList<DecayProduct> rclist, ArrayList<DecayProduct> mclist) {
-
-        // Check lengths match
-        if (rclist.size()!=mclist.size()) throw new IllegalArgumentException("List sizes do not match: rclist.size()=" + rclist.size() + ", but mclist.size()=" + mclist.size());
+    /**
+    * Smear a list of reconstructed particles given the list of MC truth particles and a matching map
+    *
+    * @param rclist
+    * @param mclist
+    * @param recMatchingMap
+    */
+    protected ArrayList<DecayProduct> smear(ArrayList<DecayProduct> rclist, ArrayList<DecayProduct> mclist, LinkedHashMap<Integer, Integer> recMatchingMap) {
 
         // Loop lists and smear
         ArrayList<DecayProduct> plist = new ArrayList<DecayProduct>();
-        for (int idx=0; idx<rclist.size(); idx++) {
-            DecayProduct p = this.smear(rclist.get(idx), mclist.get(idx));
+        for (Integer rc_idx : recMatchingMap.keySet()) {
+            Integer mc_idx = recMatchingMap.get(rc_idx);
+            DecayProduct p = this.smear(rclist.get(rc_idx), mclist.get(mc_idx));
             plist.add(p);
         }
 

--- a/app/src/main/groovy/org/jlab/analysis/MCSmearing.groovy
+++ b/app/src/main/groovy/org/jlab/analysis/MCSmearing.groovy
@@ -267,38 +267,41 @@ public class MCSmearing {
         // Get the MC momentum resolution
         double mu_mom_mc = 0.0;
         double sigma_mom_mc = 0.0;
+        double new_mom_dt = mom_dt; //NOTE: Default to reconstructed value.
         if (binid_mc>=0 && this._mc_resolution_mom_map.get(pid_dt).containsKey(binid_mc)) {
             mu_mom_mc = this._mc_resolution_mom_map.get(pid_dt).get(binid_mc).get(0);
             sigma_mom_mc = this._mc_resolution_mom_map.get(pid_dt).get(binid_mc).get(1);
-        }
 
-        // Smear the momentum
-        double sigma_mom = sigma_mom_mc * Math.sqrt((double)(1.0+this._smearing_mom*this._smearing_mom)); // Add in the additional smearing for data
-        double new_mom_dt = mom_mc * (1.0 + (this._use_mu ? mu_mom_mc : 0.0) + this._rng.nextGaussian() * sigma_mom); //NOTE: Momentum should be Delta p / p but angles are just raw difference Delta theta, Delta phi.
+            // Smear the momentum
+            double sigma_mom = sigma_mom_mc * Math.sqrt((double)(1.0+this._smearing_mom*this._smearing_mom)); // Add in the additional smearing for data
+            new_mom_dt = mom_mc * (1.0 + (this._use_mu ? mu_mom_mc : 0.0) + this._rng.nextGaussian() * sigma_mom); //NOTE: Momentum should be Delta p / p but angles are just raw difference Delta theta, Delta phi.
+        }
 
         // Get the MC theta resolution
         double mu_theta_mc = 0.0;
         double sigma_theta_mc = 0.0;
+        double new_theta_dt = theta_dt; //NOTE: Default to reconstructed value.
         if (binid_mc>=0 && this._mc_resolution_theta_map.get(pid_dt).containsKey(binid_mc)) {
             mu_theta_mc = this._mc_resolution_theta_map.get(pid_dt).get(binid_mc).get(0);
             sigma_theta_mc = this._mc_resolution_theta_map.get(pid_dt).get(binid_mc).get(1);
-        }
 
-        // Smear the theta
-        double sigma_theta = sigma_theta_mc * Math.sqrt((double)(1.0+this._smearing_theta*this._smearing_theta)); // Add in the additional smearing for data
-        double new_theta_dt = theta_mc + (this._use_mu ? mu_theta_mc : 0.0) + this._rng.nextGaussian() * sigma_theta; //NOTE: Momentum should be Delta p / p but angles are just raw difference Delta theta, Delta phi.
+            // Smear the theta
+            double sigma_theta = sigma_theta_mc * Math.sqrt((double)(1.0+this._smearing_theta*this._smearing_theta)); // Add in the additional smearing for data
+            new_theta_dt = theta_mc + (this._use_mu ? mu_theta_mc : 0.0) + this._rng.nextGaussian() * sigma_theta; //NOTE: Momentum should be Delta p / p but angles are just raw difference Delta theta, Delta phi.
+        }
 
         // Get the MC phi resolution
         double mu_phi_mc = 0.0;
         double sigma_phi_mc = 0.0;
+        double new_phi_dt = phi_dt; //NOTE: Default to reconstructed value.
         if (binid_mc>=0 && this._mc_resolution_phi_map.get(pid_dt).containsKey(binid_mc)) {
             mu_phi_mc = this._mc_resolution_phi_map.get(pid_dt).get(binid_mc).get(0);
             sigma_phi_mc = this._mc_resolution_phi_map.get(pid_dt).get(binid_mc).get(1);
-        }
 
-        // Smear the phi
-        double sigma_phi = sigma_phi_mc * Math.sqrt((double)(1.0+this._smearing_phi*this._smearing_phi)); // Add in the additional smearing for data
-        double new_phi_dt = phi_mc + (this._use_mu ? mu_phi_mc : 0.0) + this._rng.nextGaussian() * sigma_phi; //NOTE: Momentum should be Delta p / p but angles are just raw difference Delta theta, Delta phi.
+            // Smear the phi
+            double sigma_phi = sigma_phi_mc * Math.sqrt((double)(1.0+this._smearing_phi*this._smearing_phi)); // Add in the additional smearing for data
+            new_phi_dt = phi_mc + (this._use_mu ? mu_phi_mc : 0.0) + this._rng.nextGaussian() * sigma_phi; //NOTE: Momentum should be Delta p / p but angles are just raw difference Delta theta, Delta phi.
+        }
 
         // Reset momentum vector
         DecayProduct new_p = p.clone();

--- a/app/src/main/groovy/org/jlab/analysis/MCSmearing.groovy
+++ b/app/src/main/groovy/org/jlab/analysis/MCSmearing.groovy
@@ -1,6 +1,10 @@
 
 package org.jlab.analysis;
 
+// Java Imports
+import java.io.*;
+import java.util.*;
+
 // Groovy Imports
 import groovy.json.JsonSlurper;
 import java.util.Random;
@@ -20,14 +24,14 @@ public class MCSmearing {
 
     public String  _jsonpath;
 
-    double _smearing_p     = 0.50;
+    double _smearing_mom   = 0.50;
     double _smearing_theta = 0.50;
     double _smearing_phi   = 0.50;
 
-    Map<Integer, Map<Integer,Cut>> _binlims_map;
-    Map<Integer, Map<Integer,Double>> _mc_resolution_p_map;
-    Map<Integer, Map<Integer,Double>> _mc_resolution_theta_map;
-    Map<Integer, Map<Integer,Double>> _mc_resolution_phi_map;
+    LinkedHashMap<Integer, LinkedHashMap<Integer,Cut>> _bincuts_map;
+    LinkedHashMap<Integer, LinkedHashMap<Integer,Double>> _mc_resolution_mom_map;
+    LinkedHashMap<Integer, LinkedHashMap<Integer,Double>> _mc_resolution_theta_map;
+    LinkedHashMap<Integer, LinkedHashMap<Integer,Double>> _mc_resolution_phi_map;
 
     Random _rng;
 
@@ -35,46 +39,52 @@ public class MCSmearing {
 
         // Reset paths and smearing values
         this._jsonpath = jsonpath;
-        this._smearing_p = smearing_p;
+        this._smearing_mom = smearing_p;
         this._smearing_theta = smearing_theta;
         this._smearing_phi = smearing_phi;
 
         // Load the JSON data
         File jsonFile = new File(this._jsonpath);
         JsonSlurper jsonSlurper = new JsonSlurper();
-        Map<String, Object> jsonmap = (Map<String, Object>)jsonSlurper.parse(jsonFile);
-        Map<String,Map<Integer,List<Double>>> binlims_map = (Map<String,Map<Integer,List<Double>>>)jsonmap.get("binlims");
+        LinkedHashMap<String, Object> jsonmap = (LinkedHashMap<String, Object>)jsonSlurper.parse(jsonFile);
 
         // Initialize maps
-        this._binlims_map = new Map<Integer, Map<Integer,Cut>>();
-        this._mc_resolution_p_map = new Map<Integer, Map<Integer,Double>>();
-        this._mc_resolution_theta_map = new Map<Integer, Map<Integer,Double>>();
-        this._mc_resolution_phi_map = new Map<Integer, Map<Integer,Double>>();
+        this._bincuts_map = new LinkedHashMap<Integer, LinkedHashMap<Integer,Cut>>();
+        this._mc_resolution_mom_map = new LinkedHashMap<Integer, LinkedHashMap<Integer,Double>>();
+        this._mc_resolution_theta_map = new LinkedHashMap<Integer, LinkedHashMap<Integer,Double>>();
+        this._mc_resolution_phi_map = new LinkedHashMap<Integer, LinkedHashMap<Integer,Double>>();
 
-        // Add bin limits to map
-        for (Integer pid : mymap.values()) {
-            Map<Integer,Cut> new_binlim_map = new Map<Integer,Cut>();
-            for (Integer binid : mymap.get(pid).values()) {
-                double xmin = binlim_map.get(binid).at(0);
-                double xmin = binlim_map.get(binid).at(1);
+        // Load bin limits map
+        LinkedHashMap<Integer,LinkedHashMap<Integer,ArrayList<Double>>> mombinlims_map = new LinkedHashMap<Integer,LinkedHashMap<Integer,ArrayList<Double>>>();
+        if (jsonmap.containsKey("mombinlims")) {
+            System.out.println("Loading momentum bin limits ('mombinlims') map...");
+            mombinlims_map = (LinkedHashMap<Integer,LinkedHashMap<Integer,ArrayList<Double>>>)jsonmap.get("mobinlims");
+        }
+
+        // Add cuts to bin cuts map
+        for (Integer pid : mombinlims_map.keySet()) {
+            LinkedHashMap<Integer,Cut> new_binlim_map = new LinkedHashMap<Integer,Cut>();
+            for (Integer binid : mombinlims_map.get(pid).keySet()) {
+                double xmin = mombinlims_map.get(pid).get(binid).get(0);
+                double xmax = mombinlims_map.get(pid).get(binid).get(1);
                 Cut cut = (double x) -> {if(x >= xmin && x<xmax ) {return true;} else {return false;}};
                 new_binlim_map.put(binid,cut);
             }
-            this._binlims_map.put(pid,new_binlim_map);
+            this._bincuts_map.put(pid,new_binlim_map);
         }
 
         // Load MC resolution maps
-        if (jsonmap.containsKey("p")) {
-            System.out.println("Loading momentum ('p') MC resolution map...");
-            this._mc_resolution_p_map = (Map<Integer,Map<Integer,Double>>)jsonmap.get("p");
+        if (jsonmap.containsKey("mom")) {
+            System.out.println("Loading momentum ('mom') MC resolution map...");
+            this._mc_resolution_mom_map = (LinkedHashMap<Integer,LinkedHashMap<Integer,Double>>)jsonmap.get("mom");
         }
         if (jsonmap.containsKey("theta")) {
             System.out.println("Loading polar angle ('theta') MC resolution map...");
-            this._mc_resolution_theta_map = (Map<Integer,Map<Integer,Double>>)jsonmap.get("theta");
+            this._mc_resolution_theta_map = (LinkedHashMap<Integer,LinkedHashMap<Integer,Double>>)jsonmap.get("theta");
         }
         if (jsonmap.containsKey("phi")) {
             System.out.println("Loading azimuthal angle ('phi') MC resolution map...");
-            this._mc_resolution_phi_map = (Map<Integer,Map<Integer,Double>>)jsonmap.get("phi");
+            this._mc_resolution_phi_map = (LinkedHashMap<Integer,LinkedHashMap<Integer,Double>>)jsonmap.get("phi");
         }
 
         // Create random number generator
@@ -87,52 +97,46 @@ public class MCSmearing {
     * @param p_mc
     * @return new_p
     */
-    protected DecayProduct applySmearing(DecayProduct p, MCDecayProduct p_mc) {
-
-        // Generate a random Gaussian float
-        double gaussian = this._rng.nextGaussian() // mean = 0.0, std dev = 1.0
+    protected DecayProduct applySmearing(DecayProduct p, DecayProduct p_mc) {
 
         // Set PID, momentum, theta, phi for REC particle
         int pid_dt      = p.pid();
-        double p_dt     = p.p();
+        double mom_dt   = p.p();
         double theta_dt = p.theta();
         double phi_dt   = p.phi();
 
         // Set PID and momentum theta phi for REC particle
         int pid_mc      = p_mc.pid();
-        double p_mc     = p_mc.p();
+        double mom_mc   = p_mc.p();
         double theta_mc = p_mc.theta();
         double phi_mc   = p_mc.phi();
 
-        // Smear the momentum
-        double sigma_p_mc = 0.0;
-
         // Check the momentum bin
         int binid_mc = -1;
-        if (this._binlims_p_map.containsKey(pid_dt)) {
+        if (this._bincuts_map.containsKey(pid_dt)) {
 
             // Get cut map for pid
-            Map<Integer, Cut> cut_map = this._binlims_map.get(pid_dt);
+            LinkedHashMap<Integer, Cut> cut_map = this._bincuts_map.get(pid_dt);
 
             // Loop cut map
-            for (Integer binid : cut_map.values()) {
+            for (Integer binid : cut_map.keySet()) {
 
                 // Check which bin the MC truth is in
-                if (cut_map.get(binid)(p_mc)) {
+                if (cut_map.get(binid)(mom_mc)) {
                     binid_mc = binid;
                 }
             }
         }
 
         // Get the MC momentum resolution
-        double sigma_p_mc = 0.0;
-        if (binid_mc>=0 && this._mc_resolution_p_map.get(pid_dt).containsKey(binid_mc)) {
-            sigma_p_mc = this._mc_resolution_p_map.get(pid_dt).get(binid_mc);
+        double sigma_mom_mc = 0.0;
+        if (binid_mc>=0 && this._mc_resolution_mom_map.get(pid_dt).containsKey(binid_mc)) {
+            sigma_mom_mc = this._mc_resolution_mom_map.get(pid_dt).get(binid_mc);
         }
 
         // Smear the momentum
-        double sigma_p = sigma_p_mc * Math.sqrt(1.0+this._smearing_p*this._smearing_p); // Add in the additional smearing for data
-        double new_p_dt = p_mc + gaussian * sigma_p;
+        double sigma_mom = sigma_mom_mc * Math.sqrt((double)(1.0+this._smearing_mom*this._smearing_mom)); // Add in the additional smearing for data
+        double new_mom_dt = mom_mc * (1.0 + this._rng.nextGaussian() * sigma_mom);
 
         // Get the MC theta resolution
         double sigma_theta_mc = 0.0;
@@ -141,8 +145,8 @@ public class MCSmearing {
         }
 
         // Smear the theta
-        double sigma_theta = sigma_theta_mc * Math.sqrt(1.0+this._smearing_theta*this._smearing_theta); // Add in the additional smearing for data
-        double new_theta_dt = theta_mc + gaussian * sigma_theta;
+        double sigma_theta = sigma_theta_mc * Math.sqrt((double)(1.0+this._smearing_theta*this._smearing_theta)); // Add in the additional smearing for data
+        double new_theta_dt = theta_mc * (1.0 + this._rng.nextGaussian() * sigma_theta);
 
         // Get the MC phi resolution
         double sigma_phi_mc = 0.0;
@@ -151,12 +155,12 @@ public class MCSmearing {
         }
 
         // Smear the phi
-        double sigma_phi = sigma_phi_mc * Math.sqrt(1.0+this._smearing_phi*this._smearing_phi); // Add in the additional smearing for data
-        double new_phi_dt = phi_mc + gaussian * sigma_phi;
+        double sigma_phi = sigma_phi_mc * Math.sqrt((double)(1.0+this._smearing_phi*this._smearing_phi)); // Add in the additional smearing for data
+        double new_phi_dt = phi_mc * (1.0 + this._rng.nextGaussian() * sigma_phi);
 
         // Reset momentum vector
         DecayProduct new_p = p.clone();
-        new_p.setPThetaPhiM(new_p_dt, new_theta_dt, new_phi_dt, p.m());
+        new_p.setPThetaPhiM(new_mom_dt, new_theta_dt, new_phi_dt, p.m());
         return new_p;
         
     }

--- a/app/src/main/groovy/org/jlab/analysis/MCSmearing.groovy
+++ b/app/src/main/groovy/org/jlab/analysis/MCSmearing.groovy
@@ -249,7 +249,7 @@ public class MCSmearing {
 
         // Check the momentum bin
         int binid_mc = -1;
-        if (this._bincuts_map.containsKey(pid_dt)) {
+        if (this._bincuts_map.size()>0 && this._bincuts_map.containsKey(pid_dt)) {
 
             // Get cut map for pid
             LinkedHashMap<Integer, Cut> cut_map = this._bincuts_map.get(pid_dt);
@@ -268,7 +268,7 @@ public class MCSmearing {
         double mu_mom_mc = 0.0;
         double sigma_mom_mc = 0.0;
         double new_mom_dt = mom_dt; //NOTE: Default to reconstructed value.
-        if (binid_mc>=0 && this._mc_resolution_mom_map.get(pid_dt).containsKey(binid_mc)) {
+        if (this._mc_resolution_mom_map.size()>0 && binid_mc>=0 && this._mc_resolution_mom_map.get(pid_dt).containsKey(binid_mc)) {
             mu_mom_mc = this._mc_resolution_mom_map.get(pid_dt).get(binid_mc).get(0);
             sigma_mom_mc = this._mc_resolution_mom_map.get(pid_dt).get(binid_mc).get(1);
 
@@ -281,7 +281,7 @@ public class MCSmearing {
         double mu_theta_mc = 0.0;
         double sigma_theta_mc = 0.0;
         double new_theta_dt = theta_dt; //NOTE: Default to reconstructed value.
-        if (binid_mc>=0 && this._mc_resolution_theta_map.get(pid_dt).containsKey(binid_mc)) {
+        if (this._mc_resolution_theta_map.size()>0 && binid_mc>=0 && this._mc_resolution_theta_map.get(pid_dt).containsKey(binid_mc)) {
             mu_theta_mc = this._mc_resolution_theta_map.get(pid_dt).get(binid_mc).get(0);
             sigma_theta_mc = this._mc_resolution_theta_map.get(pid_dt).get(binid_mc).get(1);
 
@@ -294,7 +294,7 @@ public class MCSmearing {
         double mu_phi_mc = 0.0;
         double sigma_phi_mc = 0.0;
         double new_phi_dt = phi_dt; //NOTE: Default to reconstructed value.
-        if (binid_mc>=0 && this._mc_resolution_phi_map.get(pid_dt).containsKey(binid_mc)) {
+        if (this._mc_resolution_phi_map.size()>0 && binid_mc>=0 && this._mc_resolution_phi_map.get(pid_dt).containsKey(binid_mc)) {
             mu_phi_mc = this._mc_resolution_phi_map.get(pid_dt).get(binid_mc).get(0);
             sigma_phi_mc = this._mc_resolution_phi_map.get(pid_dt).get(binid_mc).get(1);
 

--- a/app/src/main/groovy/org/jlab/analysis/MCSmearing.groovy
+++ b/app/src/main/groovy/org/jlab/analysis/MCSmearing.groovy
@@ -37,14 +37,85 @@ public class MCSmearing {
 
     boolean _use_mu = false;
 
-    public MCSmearing(String jsonpath, double smearing_p, double smearing_theta, double smearing_phi, boolean use_mu) {
+    public MCSmearing() {
+
+        // Initialize maps
+        this._bincuts_map = new LinkedHashMap<Integer, LinkedHashMap<Integer,Cut>>();
+        this._mc_resolution_mom_map = new LinkedHashMap<Integer, LinkedHashMap<Integer,ArrayList<Double>>>();
+        this._mc_resolution_theta_map = new LinkedHashMap<Integer, LinkedHashMap<Integer,ArrayList<Double>>>();
+        this._mc_resolution_phi_map = new LinkedHashMap<Integer, LinkedHashMap<Integer,ArrayList<Double>>>();
+
+        // Create random number generator
+        this._rng = new Random();
+    }
+
+    public MCSmearing(double smearing_mom, double smearing_theta, double smearing_phi, boolean use_mu) {
 
         // Reset paths and smearing values
-        this._jsonpath = jsonpath;
-        this._smearing_mom = smearing_p;
+        this._smearing_mom = smearing_mom;
         this._smearing_theta = smearing_theta;
         this._smearing_phi = smearing_phi;
         this._use_mu = use_mu
+
+        // Initialize maps
+        this._bincuts_map = new LinkedHashMap<Integer, LinkedHashMap<Integer,Cut>>();
+        this._mc_resolution_mom_map = new LinkedHashMap<Integer, LinkedHashMap<Integer,ArrayList<Double>>>();
+        this._mc_resolution_theta_map = new LinkedHashMap<Integer, LinkedHashMap<Integer,ArrayList<Double>>>();
+        this._mc_resolution_phi_map = new LinkedHashMap<Integer, LinkedHashMap<Integer,ArrayList<Double>>>();
+
+        // Create random number generator
+        this._rng = new Random();
+    }
+
+    /**
+    * Set data smearing fraction for momentum.
+    * @param smearing_mom
+    */
+    protected void setMomSmearing(double smearing_mom) {
+        this._smearing_mom = smearing_mom;
+    }
+
+    /**
+    * Set data smearing fraction for theta.
+    * @param smearing_theta
+    */
+    protected void setThetaSmearing(double smearing_theta) {
+        this._smearing_theta = smearing_theta;
+    }
+
+    /**
+    * Set data smearing fraction for phi.
+    * @param smearing_phi
+    */
+    protected void setPhiSmearing(double smearing_phi) {
+        this._smearing_phi = smearing_phi;
+    }
+
+    /**
+    * Set data smearing fractions for momentum, theta, and phi.
+    * @param smearing_mom
+    * @param smearing_theta
+    * @param smearing_phi
+    */
+    protected void setSmearing(double smearing_mom, double smearing_theta, double smearing_phi) {
+        this._smearing_mom = smearing_mom;
+        this._smearing_theta = smearing_theta;
+        this._smearing_phi = smearing_phi;
+    }
+
+    /**
+    * Set option to use means of smearing distributions to offset MC truth values.
+    * @param use_mu
+    */
+    protected void setUseMu(boolean use_mu) {
+        this._use_mu = use_mu;
+    }
+
+    /**
+    * Load smearing maps from a JSON file.
+    * @param jsonpath
+    */
+    protected void loadJSON(String jsonpath) {
 
         // Load the JSON data
         File jsonFile = new File(this._jsonpath);
@@ -95,12 +166,12 @@ public class MCSmearing {
     }
 
     /**
-    * Apply MC smearing to a given particle and MC truth particle
+    * Smear the momentum, theta, and phi of a reconstructed particle and an MC truth particle.
     * @param p
     * @param p_mc
     * @return new_p
     */
-    protected DecayProduct applySmearing(DecayProduct p, DecayProduct p_mc) {
+    protected DecayProduct smear(DecayProduct p, DecayProduct p_mc) {
 
         // Set PID, momentum, theta, phi for REC particle
         int pid_dt      = p.pid();
@@ -172,6 +243,21 @@ public class MCSmearing {
         new_p.setPThetaPhiM(new_mom_dt, new_theta_dt, new_phi_dt, p.m());
         return new_p;
         
+    }
+
+    protected ArrayList<DecayProduct> smear(ArrayList<DecayProduct> rclist, ArrayList<DecayProduct> mclist) {
+
+        // Check lengths match
+        if (rclist.size()!=mclist.size()) throw new IllegalArgumentException("List sizes do not match: rclist.size()=" + rclist.size() + ", but mclist.size()=" + mclist.size());
+
+        // Loop lists and smear
+        ArrayList<DecayProduct> plist = new ArrayList<DecayProduct>();
+        for (int idx=0; idx<rclist.size(); idx++) {
+            DecayProduct p = this.smear(rclist.get(idx), mclist.get(idx));
+            plist.add(p);
+        }
+
+        return plist;
     }
 
 } // public class MCSmearing {

--- a/app/src/main/groovy/org/jlab/analysis/MCSmearing.groovy
+++ b/app/src/main/groovy/org/jlab/analysis/MCSmearing.groovy
@@ -318,7 +318,7 @@ public class MCSmearing {
         ArrayList<DecayProduct> plist = new ArrayList<DecayProduct>();
         for (Integer rc_idx : recMatchingMap.keySet()) {
             Integer mc_idx = recMatchingMap.get(rc_idx);
-            DecayProduct p = this.smear(rclist.get(rc_idx), mclist.get(mc_idx));
+            DecayProduct p = (mc_idx>=0) ? this.smear(rclist.get(rc_idx), mclist.get(mc_idx)) : rclist.get(rc_idx);
             plist.add(p);
         }
 

--- a/app/src/main/groovy/org/jlab/analysis/MCSmearing.groovy
+++ b/app/src/main/groovy/org/jlab/analysis/MCSmearing.groovy
@@ -256,7 +256,7 @@ public class MCSmearing {
             for (Integer binid : cut_map.keySet()) {
 
                 // Check which bin the MC truth is in
-                if (cut_map.get(binid)(mom_mc)) {
+                if (cut_map.get(binid).cut(mom_mc)) {
                     binid_mc = binid;
                 }
             }

--- a/app/src/main/groovy/org/jlab/analysis/MCSmearing.groovy
+++ b/app/src/main/groovy/org/jlab/analysis/MCSmearing.groovy
@@ -174,7 +174,7 @@ public class MCSmearing {
         // Load MC resolution maps
         if (jsonmap.containsKey(this._resolution_mom_map_key)) {
             System.out.println("Loading momentum ('"+this._resolution_mom_map_key+"') MC resolution map...");
-            LinkedHashMap<String,LinkedHashMap<String,ArrayList<Double>>> mc_resolution_mom_map = (LinkedHashMap<String,LinkedHashMap<String,ArrayList<Double>>>)jsonmap.get(this._resolution_mom_map_key);
+            LinkedHashMap<String,LinkedHashMap<String,ArrayList<Double>>> mc_resolution_mom_map = jsonmap.get(this._resolution_mom_map_key);
 
             // Add entries to map using correct types since JSON only stores keys as strings
             for (String str_pid : mc_resolution_mom_map.keySet()) {
@@ -190,7 +190,7 @@ public class MCSmearing {
         }
         if (jsonmap.containsKey(this._resolution_theta_map_key)) {
             System.out.println("Loading polar angle ('"+this._resolution_theta_map_key+"') MC resolution map...");
-            LinkedHashMap<String,LinkedHashMap<String,ArrayList<Double>>> mc_resolution_theta_map = (LinkedHashMap<String,LinkedHashMap<String,ArrayList<Double>>>)jsonmap.get(this._resolution_theta_map_key);
+            LinkedHashMap<String,LinkedHashMap<String,ArrayList<Double>>> mc_resolution_theta_map = jsonmap.get(this._resolution_theta_map_key);
 
             // Add entries to map using correct types since JSON only stores keys as strings
             for (String str_pid : mc_resolution_theta_map.keySet()) {
@@ -206,7 +206,7 @@ public class MCSmearing {
         }
         if (jsonmap.containsKey(this._resolution_phi_map_key)) {
             System.out.println("Loading azimuthal angle ('"+this._resolution_phi_map_key+"') MC resolution map...");
-            LinkedHashMap<String,LinkedHashMap<String,ArrayList<Double>>> mc_resolution_phi_map = (LinkedHashMap<String,LinkedHashMap<String,ArrayList<Double>>>)jsonmap.get(this._resolution_phi_map_key);
+            LinkedHashMap<String,LinkedHashMap<String,ArrayList<Double>>> mc_resolution_phi_map = jsonmap.get(this._resolution_phi_map_key);
 
             // Add entries to map using correct types since JSON only stores keys as strings
             for (String str_pid : mc_resolution_phi_map.keySet()) {

--- a/app/src/main/groovy/org/jlab/analysis/Parser.groovy
+++ b/app/src/main/groovy/org/jlab/analysis/Parser.groovy
@@ -96,6 +96,16 @@ public class Parser {
         System.out.println("\t                           * dataset (Fall2018 or Spring2019)");
         System.out.println("\t                           * pass version (1,2,3,...)");
         System.out.println("\t                           * outbending (0 : false, 1 : true)");
+        System.out.println("\t-mcsmear [string, double, double, double, bool] : Use MC smearing. Parameters:");
+        System.out.println("\t                           * path to JSON file containing:");
+        System.out.println("\t                               - 'mombinlims' : Map of PIDs to bin ids to bin limits");
+        System.out.println("\t                               - 'mombinlims' : Map of PIDs to bin ids to bin limits");
+        System.out.println("\t                               - 'mombinlims' : Map of PIDs to bin ids to bin limits");
+        System.out.println("\t                               - 'mombinlims' : Map of PIDs to bin ids to bin limits");
+        System.out.println("\t                           * Momentum additional data smearing fraction");
+        System.out.println("\t                           * Theta additional data smearing fraction");
+        System.out.println("\t                           * Phi additional data smearing fraction");
+        System.out.println("\t                           * Option to offset by means (mus) of smearing distributions");
         System.out.println("\t-xF   [float]  : Minimum xF cut for events          (def: none)");
         System.out.println("\t-m    [float]  : Maximum mass cut for events        (def: none)");
         System.out.println("\t-'[var]>(<)[float]' : Cut kinematic variable");
@@ -379,6 +389,16 @@ public class Parser {
                 case "-momc":
                     if (args.length>2) { try { analysis.setMCVersion(args[i+1],Integer.parseInt(args[i+2]),Integer.parseInt(args[i+3])); valid_opt = true; break; }
                     catch (Exception exception) { System.out.println(" WARNING: Using Momentum Correction version for dataset: Fall2018, pass: 1."); } }
+
+                // Momentum corrections option
+                case "-mcsmear":
+                    if (args.length>2) { try {
+                        analysis.setMCSmearing(true);
+                        analysis.loadMCSmearingJSON(args[i+1]);
+                        analysis.setMCSmearing(Double.parseDouble(args[i+2]),Double.parseDouble(args[i+3]),Double.parseDouble(args[i+4]));
+                        analysis.setMCSmearingUseMu(Boolean.parseBoolean(args[i+5]));
+                        valid_opt = true; break;
+                    } catch (Exception exception) { return this.help(); } }
 
                 // PID tag option
                 case "-tag":

--- a/app/src/main/groovy/org/jlab/analysis/Parser.groovy
+++ b/app/src/main/groovy/org/jlab/analysis/Parser.groovy
@@ -98,10 +98,10 @@ public class Parser {
         System.out.println("\t                           * outbending (0 : false, 1 : true)");
         System.out.println("\t-mcsmear [string, double, double, double, bool] : Use MC smearing. Parameters:");
         System.out.println("\t                           * path to JSON file containing:");
-        System.out.println("\t                               - 'mombinlims' : Map of PIDs to bin ids to bin limits");
-        System.out.println("\t                               - 'mombinlims' : Map of PIDs to bin ids to bin limits");
-        System.out.println("\t                               - 'mombinlims' : Map of PIDs to bin ids to bin limits");
-        System.out.println("\t                               - 'mombinlims' : Map of PIDs to bin ids to bin limits");
+        System.out.println("\t                               - 'mombinlims' : Map of PIDs to bin ids to momentum bin limits");
+        System.out.println("\t                               - 'mom'        : Map of PIDs to bin ids to delta p / p means and widths");
+        System.out.println("\t                               - 'theta'      : Map of PIDs to bin ids to delta theta means and widths");
+        System.out.println("\t                               - 'phi'        : Map of PIDs to bin ids to delta phi means and widths");
         System.out.println("\t                           * Momentum additional data smearing fraction");
         System.out.println("\t                           * Theta additional data smearing fraction");
         System.out.println("\t                           * Phi additional data smearing fraction");


### PR DESCRIPTION
This adds a new command line option `-mcsmear [string double double double bool]` which allows you to provide a JSON file specifying the momentum bin dependent smearing parameters for $\Delta p/p_{MC}$, $\Delta \theta$, and $\Delta \phi$.

Values are smearing in a Gaussian distribution about the MC truth value + the mean $\mu$ of the resolution distribution.  The width of the Gaussian is taken from the provided widths of the resolution distributions and an additional amount of smearing may be added in quadrature: $\sigma=\sqrt{\sigma_{Fit}^2+\sigma_{Additional}}$.

If no smearing parameters are provided for a particular PID or momentum bin, then the reconstructed values are left unchanged.